### PR TITLE
Explicity require dependencies.

### DIFF
--- a/lib/yesmail2/api_base.rb
+++ b/lib/yesmail2/api_base.rb
@@ -1,3 +1,7 @@
+require 'hashie'
+require 'json'
+require 'rest_client'
+
 module Yesmail2
   class ApiBase
     require_relative 'logging'

--- a/lib/yesmail2/config.rb
+++ b/lib/yesmail2/config.rb
@@ -1,3 +1,5 @@
+require 'hashie'
+require 'logger'
 
 module Yesmail2
   def self.config

--- a/lib/yesmail2/subscriber.rb
+++ b/lib/yesmail2/subscriber.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module Yesmail2
 
   # Note that when the yesmail documentation refers to a subscriber ID, in

--- a/yesmail2.gemspec
+++ b/yesmail2.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'yesmail2'
-  s.version     = '0.0.1'
+  s.version     = '0.0.2'
   s.date        = '2013-09-12'
   s.summary     = "Yesmail v2"
   s.description = "Ruby wrapper for v2 of the yesmail API"
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files       = Dir["lib/**/*.rb"]
   s.require_paths = ['lib']
   s.homepage      = 'https://github.com/apartmentlist/yesmail2'
- 
+
   s.add_dependency 'rest-client'
   s.add_dependency 'json'
   s.add_dependency 'logger'


### PR DESCRIPTION
An app using this gem may not have already required these dependencies.
