### PR TITLE
Put all successful responses in Hashie::Mash

### DIFF
--- a/lib/yesmail2/api_base.rb
+++ b/lib/yesmail2/api_base.rb
@@ -73,9 +73,13 @@ module Yesmail2
       _args[1] = _args[1].dup
 
       r = RestClient.send(method, *_args) do |response, request, result, &block|
-        case response.code
-        when 200
-          r = Hashie::Mash.new(JSON.parse(response))
+        # Look for any successful response code: 2XX
+        if response.code.to_s =~ /2../
+          # In some cases, Yesmail's response is an empty string, which is not
+          # valid JSON, just pretend we got an empty hash so we can pass that
+          # to Hashie with no issues.
+          hash = response == '' ? {} : JSON.parse(response)
+          r = Hashie::Mash.new(hash)
           log_request(request)
           log_response(response)
           r

--- a/spec/yesmail2/api_base_spec.rb
+++ b/spec/yesmail2/api_base_spec.rb
@@ -24,6 +24,39 @@ module Yesmail2
 
         ApiBase.http_method(:get, url)
       end
+
+      it 'returns a Hashie::Mash representing the JSON response' do
+        WebMock.stub_request(:get, url)
+          .to_return(status: 200, body: '{"foo":"bar","biz":3}')
+
+        result = ApiBase.http_method(:get, url)
+        result.should be_a(Hashie::Mash)
+        result.foo.should eq('bar')
+        result.biz.should eq(3)
+      end
+
+      context 'when the response code is 202' do
+        it 'returns a Hashie::Mash representing the JSON response' do
+          WebMock.stub_request(:get, url)
+            .to_return(status: 202, body: '{"foo":"bar","biz":3}')
+
+          result = ApiBase.http_method(:get, url)
+          result.should be_a(Hashie::Mash)
+          result.foo.should eq('bar')
+          result.biz.should eq(3)
+        end
+      end
+
+      context 'when the response body is empty' do
+        before do
+          WebMock.stub_request(:get, url)
+            .to_return(status: 200, body: '')
+        end
+
+        it 'returns a Hashie for a blank response' do
+          ApiBase.http_method(:get, url).should be_a(Hashie::Mash)
+        end
+      end
     end
   end
 end

--- a/yesmail2.gemspec
+++ b/yesmail2.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'yesmail2'
-  s.version     = '0.0.5'
+  s.version     = '0.0.6'
   s.date        = '2013-09-12'
   s.summary     = "Yesmail v2"
   s.description = "Ruby wrapper for v2 of the yesmail API"


### PR DESCRIPTION
Before only responses with code == 200 were being put in a Hashie::Mash. However Yesmail can respond with 202, 204, etc codes for successful requests. These will all be handled just like a 200.
