### PR TITLE
Parameter name change for update_subscribers method

### DIFF
--- a/lib/yesmail2/subscriber.rb
+++ b/lib/yesmail2/subscriber.rb
@@ -155,12 +155,12 @@ module Yesmail2
     #   the users already exists and has been marked as unsubscribed, should
     #   this attempt to resubscribe them still work?
     def self.update_subscribers(subscribers, divisions, subscriptions = [],
-        existing_subscribers = 'update', resubscribe = false)
+        import_type = 'update', resubscribe = false)
 
       divisions = [divisions] if divisions.is_a?(String)
 
       data = {
-        :existingSubscribers => existing_subscribers,
+        :importType => import_type,
         :resubscribe => resubscribe,
         :memberOf => divisions,
         :subscribers => subscribers


### PR DESCRIPTION
There was a parameter name changed for Yesmails **subscribers/import** method (existingSubscribers changed to importType).  You can find it here [YesMail v2 API](https://developer.yesmail.com/post-subscribersimport).
