### PR TITLE
Replaced deprecated records/update method

### DIFF
--- a/lib/yesmail2/reference_data.rb
+++ b/lib/yesmail2/reference_data.rb
@@ -73,8 +73,8 @@ module Yesmail2
     # },
     #
     def self.upsert_records(dataset_name, records)
-      #POST reference-data/{dataset}/records/update
-      r = post(full_path(dataset_name, 'records', 'update'), records.to_json, :content_type => :json, :accept => :json)
+      #POST reference-data/{dataset}/records/import
+      r = post(full_path(dataset_name, 'records', 'import'), records.to_json, :content_type => :json, :accept => :json)
     end
 
     # WARN: this code is untested


### PR DESCRIPTION
As per Yesmails engineers, the **reference-data/{dataset}/records/update** method has been deprecated and should be replaced with **reference-data/{dataset}/records/import**.  You can find the documentation here [YesMail v2 API](https://developer.yesmail.com/post-reference-datadatasetrecordsimport).
